### PR TITLE
优化扩展包版本指定问题

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,12 +5,12 @@
 	"version":"3.0.2",
 	"require" : {
 		"php" : ">=5.6.0",
-		"guzzlehttp/guzzle" : "6.3.0",
-		"guzzlehttp/psr7" : "1.4.2",
-		"guzzlehttp/promises" : "1.3.1",
-		"psr/http-message" : "1.0.1",
-		"monolog/monolog" : "1.*",
-		"psr/log" : "1.*"
+		"guzzlehttp/guzzle" : "^6.3.0",
+		"guzzlehttp/psr7" : "^1.4.2",
+		"guzzlehttp/promises" : "^1.3.1",
+		"psr/http-message" : "^1.0.1",
+		"monolog/monolog" : "^1.23.0",
+		"psr/log" : "^1.0.2"
 	},
 	
 	"keywords" :["obs", "php"],

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
 		"guzzlehttp/psr7" : "1.4.2",
 		"guzzlehttp/promises" : "1.3.1",
 		"psr/http-message" : "1.0.1",
-		"monolog/monolog" : "1.23.0",
-		"psr/log" : "1.0.2"
+		"monolog/monolog" : "1.*",
+		"psr/log" : "1.*"
 	},
 	
 	"keywords" :["obs", "php"],


### PR DESCRIPTION
guzzlehttp、monolog、psr/log等为常用扩展版，不适合写死版本号。否则不利于集成到现有框架或项目
