### PR TITLE
更新psr/log到1.0以上即可（monolog的要求）

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		"guzzlehttp/promises" : "1.3.1",
 		"psr/http-message" : "1.0.1",
 		"monolog/monolog" : "1.23.0",
-		"psr/log" : "1.0.2"
+		"psr/log" : "~1.0"
 	},
 	
 	"keywords" :["obs", "php"],


### PR DESCRIPTION
请更新psr/log的版本为   
monolog/monolog 1.23.0版本要求的
```
    "require": {
        "php": ">=5.3.0",
        "psr/log": "~1.0"
    },
```
原本的1.0.2和较新的框架冲突