### PR TITLE
fixed:临时下载凭证x-obs-security-token的obs验签失败的问题

### DIFF
--- a/Obs/Internal/Resource/Constants.php
+++ b/Obs/Internal/Resource/Constants.php
@@ -49,6 +49,7 @@ class Constants {
             'response-content-disposition',
             'response-content-encoding',
             'x-image-process',
+            'x-obs-security-token',
 
             'backtosource',
             'storageclass',


### PR DESCRIPTION
使用临时凭证security-token连接的客户端，签名方式使用obs的时候，通过createSignedUrl获取的签名下载地址，会提示SignatureDoesNotMatch，签名验证失败。是因为x-obs-security-token并没有参与签名计算。