### PR TITLE
fix: allow psr/http message v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name" : "obs/esdk-obs-php",
+	"name" : "mubbi/esdk-obs-php",
 	"description" : "OBS PHP SDK",
 	"license":"Apache-2.0",
 	"version":"3.24.9",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 		"guzzlehttp/guzzle" : "^6.3.0 || ^7.0",
 		"guzzlehttp/psr7" : "^1.4.2 || ^2.0",
 		"monolog/monolog" : "^1.23.0 || ^2.0 || ^3.0",
-        "psr/http-message": "^1.0"
+    "psr/http-message": "^1.0 || ^2.0"
 	},
 	
 	"keywords" :["obs", "php"],

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name" : "mubbi/esdk-obs-php",
 	"description" : "OBS PHP SDK",
 	"license":"Apache-2.0",
-	"version":"3.24.9",
+	"version":"3.24.10",
 	"require" : {
 		"php" : ">=5.6.0",
 		"guzzlehttp/guzzle" : "^6.3.0 || ^7.0",


### PR DESCRIPTION
This pull request updates the `composer.json` file to expand compatibility with newer versions of the `psr/http-message` package.

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L11-R11): Updated the version constraint for `psr/http-message` to include compatibility with version 2.0, in addition to version 1.0.